### PR TITLE
Remover fixtures dos testes de PedidoService

### DIFF
--- a/juliopedidoapi/src/test/java/br/edu/infnet/juliopedidoapi/PedidoServiceTest.java
+++ b/juliopedidoapi/src/test/java/br/edu/infnet/juliopedidoapi/PedidoServiceTest.java
@@ -30,9 +30,9 @@ class PedidoServiceTest {
         @DisplayName("RF003.01 - Deve calcular o valor total somando os subtotais dos itens válidos")
         void deveSomarOsSubtotaisDosItensValidos() {
 
-                ItemPedido primeiroItem = ItemPedidoFixture.criarItemPedido(2, "100.00");
-                ItemPedido segundoItem = ItemPedidoFixture.criarItemPedido(3, "50.00");
-                Pedido pedido = PedidoFixture.criarPedidoComItens(primeiroItem, segundoItem);
+                ItemPedido primeiroItem = criarItemPedido(2, new BigDecimal("100.00"));
+                ItemPedido segundoItem = criarItemPedido(3, new BigDecimal("50.00"));
+                Pedido pedido = criarPedidoComItens(primeiroItem, segundoItem);
 
                 BigDecimal subtotalEsperado = primeiroItem.calcularSubtotal().add(segundoItem.calcularSubtotal());
 
@@ -63,8 +63,8 @@ class PedidoServiceTest {
         @Test
         @DisplayName("RF003.04 - Deve lançar IllegalArgumentException quando existirem itens com quantidade inválida")
         void deveLancarIllegalArgumentException_QuandoExistirItemComQuantidadeInvalida() {
-                ItemPedido itemInvalido = ItemPedidoFixture.criarItemPedido(0, "100.00");
-                Pedido pedido = PedidoFixture.criarPedidoComItens(itemInvalido);
+                ItemPedido itemInvalido = criarItemPedido(0, new BigDecimal("100.00"));
+                Pedido pedido = criarPedidoComItens(itemInvalido);
 
                 assertThrows(IllegalArgumentException.class, () -> pedidoService.calcularValorTotal(pedido),
                                 "Itens com quantidade inválida devem interromper o cálculo do pedido.");
@@ -73,46 +73,32 @@ class PedidoServiceTest {
         @Test
         @DisplayName("RF003.05 - Deve lançar IllegalArgumentException quando existirem itens com valor inválido")
         void deveLancarIllegalArgumentException_QuandoExistirItemComValorInvalido() {
-                ItemPedido itemValorNulo = ItemPedidoFixture.criarItemPedidoComValorNulo(1);
-                Pedido pedido = PedidoFixture.criarPedidoComItens(itemValorNulo);
+                ItemPedido itemValorNulo = criarItemPedidoComValorNulo(1);
+                Pedido pedido = criarPedidoComItens(itemValorNulo);
 
                 assertThrows(IllegalArgumentException.class, () -> pedidoService.calcularValorTotal(pedido),
                                 "Itens com valor inválido devem interromper o cálculo do pedido.");
         }
 
-        private static class PedidoFixture {
-                private PedidoFixture() {
-                }
-
-                static Pedido criarPedidoComItens(ItemPedido... itens) {
-                        Pedido pedido = new Pedido();
-                        pedido.setItens(Arrays.asList(itens));
-                        return pedido;
-                }
+        private Pedido criarPedidoComItens(ItemPedido... itens) {
+                Pedido pedido = new Pedido();
+                pedido.setItens(Arrays.asList(itens));
+                return pedido;
         }
 
-        private static class ItemPedidoFixture {
-                private ItemPedidoFixture() {
-                }
+        private ItemPedido criarItemPedido(int quantidade, BigDecimal valorUnitario) {
+                ItemPedido itemPedido = new ItemPedido();
+                itemPedido.setQuantidade(quantidade);
+                itemPedido.setTarefa(new Tarefa(1, "Tarefa padrão", "TAR-001", TipoTarefa.ALINHAMENTO,
+                                valorUnitario, "ABERTO"));
+                return itemPedido;
+        }
 
-                static ItemPedido criarItemPedido(int quantidade, String valorUnitario) {
-                        ItemPedido itemPedido = new ItemPedido();
-                        itemPedido.setQuantidade(quantidade);
-                        itemPedido.setTarefa(criarTarefaPadrao(valorUnitario));
-                        return itemPedido;
-                }
-
-                static ItemPedido criarItemPedidoComValorNulo(int quantidade) {
-                        ItemPedido itemPedido = new ItemPedido();
-                        itemPedido.setQuantidade(quantidade);
-                        itemPedido.setTarefa(new Tarefa(1, "Tarefa inválida", "TAR-001", TipoTarefa.ALINHAMENTO, null,
-                                        "ABERTO"));
-                        return itemPedido;
-                }
-
-                private static Tarefa criarTarefaPadrao(String valorUnitario) {
-                        return new Tarefa(1, "Tarefa padrão", "TAR-001", TipoTarefa.ALINHAMENTO,
-                                        new BigDecimal(valorUnitario), "ABERTO");
-                }
+        private ItemPedido criarItemPedidoComValorNulo(int quantidade) {
+                ItemPedido itemPedido = new ItemPedido();
+                itemPedido.setQuantidade(quantidade);
+                itemPedido.setTarefa(new Tarefa(1, "Tarefa inválida", "TAR-001", TipoTarefa.ALINHAMENTO, null,
+                                "ABERTO"));
+                return itemPedido;
         }
 }


### PR DESCRIPTION
## Summary
- monta manualmente os itens de pedido e pedidos nos testes de `PedidoService`, eliminando a dependência de fixtures

## Testing
- mvn test *(falha: não foi possível baixar o parent POM do Spring Boot por falta de acesso à internet)*

------
https://chatgpt.com/codex/tasks/task_e_68d0831406188323bbc5018e81221627