### PR TITLE
feat: share domain entities across modules

### DIFF
--- a/julio-parent/common-domain/pom.xml
+++ b/julio-parent/common-domain/pom.xml
@@ -1,49 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	
-	<parent>
-		<groupId>br.edu.infnet.mono</groupId>
-		<artifactId>julio-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version> 
-	</parent>
-	
-	<artifactId>common-domain</artifactId>
-	<name>common-domain</name>
-	<description>Entidades comuns do projeto</description>
-	<packaging>jar</packaging>
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+        <modelVersion>4.0.0</modelVersion>
 
-	<properties>
-		<java.version>21</java.version>
-	</properties>
+        <parent>
+                <groupId>br.edu.infnet.mono</groupId>
+                <artifactId>julio-parent</artifactId>
+                <version>0.0.1-SNAPSHOT</version>
+        </parent>
 
-	<dependencies>
-        <dependency>
-            <groupId>jakarta.persistence</groupId>
-            <artifactId>jakarta.persistence-api</artifactId>
-        </dependency>
-		<dependency>
-			<groupId>br.edu.infnet.mono</groupId>
-			<artifactId>external-api</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>jakarta.validation</groupId>
-			<artifactId>jakarta.validation-api</artifactId>
-			<version>3.0.2</version>
-		</dependency>
-	</dependencies>
+        <artifactId>common-domain</artifactId>
+        <name>common-domain</name>
+        <description>Entidades comuns do projeto</description>
+        <packaging>jar</packaging>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.14.0</version>
-				<configuration>
-					<release>${java.version}</release>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
+        <properties>
+                <java.version>21</java.version>
+        </properties>
+
+        <dependencies>
+                <dependency>
+                        <groupId>jakarta.persistence</groupId>
+                        <artifactId>jakarta.persistence-api</artifactId>
+                </dependency>
+        </dependencies>
+
+        <build>
+                <plugins>
+                        <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-compiler-plugin</artifactId>
+                                <version>3.14.0</version>
+                                <configuration>
+                                        <release>${java.version}</release>
+                                </configuration>
+                        </plugin>
+                </plugins>
+        </build>
 </project>

--- a/julio-parent/common-domain/src/main/java/br/edu/infnet/mono/model/domain/CarrosPedido.java
+++ b/julio-parent/common-domain/src/main/java/br/edu/infnet/mono/model/domain/CarrosPedido.java
@@ -1,0 +1,43 @@
+package br.edu.infnet.mono.model.domain;
+
+import java.util.List;
+
+public class CarrosPedido {
+
+    private String name;
+    private List<String> listadeveiculos;
+    private String code;
+    private String ano;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<String> getListadeveiculos() {
+        return listadeveiculos;
+    }
+
+    public void setListadeveiculos(List<String> listadeveiculos) {
+        this.listadeveiculos = listadeveiculos;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public String getAno() {
+        return ano;
+    }
+
+    public void setAno(String ano) {
+        this.ano = ano;
+    }
+}

--- a/julio-parent/common-domain/src/main/java/br/edu/infnet/mono/model/domain/Cliente.java
+++ b/julio-parent/common-domain/src/main/java/br/edu/infnet/mono/model/domain/Cliente.java
@@ -1,31 +1,111 @@
 package br.edu.infnet.mono.model.domain;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 
 @Entity
-@Table(name = "cliente")
-public class Cliente {
+public class Cliente extends Pessoa {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id;
+    private double limiteCredito;
 
-    @NotBlank
-    private String cpf;
+    private boolean possuiFiado;
 
-    private String nome;
+    private int pontosFidelidade;
 
-    public Integer getId() { return id; }
-    public void setId(Integer id) { this.id = id; }
+    private String dataNascimento;
 
-    public String getCpf() { return cpf; }
-    public void setCpf(String cpf) { this.cpf = cpf; }
+    private String dataUltimaVisita;
 
-    public String getNome() { return nome; }
-    public void setNome(String nome) { this.nome = nome; }
+    @OneToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "endereco_id")
+    private Endereco endereco;
+
+    @OneToMany(mappedBy = "cliente", cascade = CascadeType.ALL)
+    private List<TicketTarefa> tickettarefas = new ArrayList<>();
+
+    @OneToMany(mappedBy = "cliente", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<Tarefa> tarefas = new ArrayList<>();
+
+    @Override
+    public String obterTipo() {
+        return "Cliente";
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "Cliente{%s, dataNascimento=%s, dataUltimaVisita=%s, limiteCredito=%.2f, possuiFiado=%s, pontosFidelidade=%d, endereco=%s}",
+                super.toString(), dataNascimento, dataUltimaVisita, limiteCredito, possuiFiado, pontosFidelidade, endereco);
+    }
+
+    public double getLimiteCredito() {
+        return limiteCredito;
+    }
+
+    public void setLimiteCredito(double limiteCredito) {
+        this.limiteCredito = limiteCredito;
+    }
+
+    public boolean isPossuiFiado() {
+        return possuiFiado;
+    }
+
+    public void setPossuiFiado(boolean possuiFiado) {
+        this.possuiFiado = possuiFiado;
+    }
+
+    public int getPontosFidelidade() {
+        return pontosFidelidade;
+    }
+
+    public void setPontosFidelidade(int pontosFidelidade) {
+        this.pontosFidelidade = pontosFidelidade;
+    }
+
+    public String getDataNascimento() {
+        return dataNascimento;
+    }
+
+    public void setDataNascimento(String dataNascimento) {
+        this.dataNascimento = dataNascimento;
+    }
+
+    public String getDataUltimaVisita() {
+        return dataUltimaVisita;
+    }
+
+    public void setDataUltimaVisita(String dataUltimaVisita) {
+        this.dataUltimaVisita = dataUltimaVisita;
+    }
+
+    public Endereco getEndereco() {
+        return endereco;
+    }
+
+    public void setEndereco(Endereco endereco) {
+        this.endereco = endereco;
+    }
+
+    public List<TicketTarefa> getTickettarefas() {
+        return tickettarefas;
+    }
+
+    public void setTickettarefas(List<TicketTarefa> tickettarefas) {
+        this.tickettarefas = tickettarefas;
+    }
+
+    public List<Tarefa> getTarefas() {
+        return tarefas;
+    }
+
+    public void setTarefas(List<Tarefa> tarefas) {
+        this.tarefas = tarefas;
+    }
 }

--- a/julio-parent/common-domain/src/main/java/br/edu/infnet/mono/model/domain/Endereco.java
+++ b/julio-parent/common-domain/src/main/java/br/edu/infnet/mono/model/domain/Endereco.java
@@ -4,87 +4,114 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Table;
 
 @Entity
-@Table(name = "enderecos")
 public class Endereco {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Integer id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
 
-	private String cep;
-	private String logradouro;
-	private String complemento;
-	private String bairro;
-	private String localidade;
-	private String uf;
-	private String estado;
+    private String cep;
 
-	// Getters e Setters
-	public Integer getId() {
-		return id;
-	}
+    private String logradouro;
 
-	public void setId(Integer id) {
-		this.id = id;
-	}
+    private String complemento;
 
-	public String getCep() {
-		return cep;
-	}
+    private String numero;
 
-	public void setCep(String cep) {
-		this.cep = cep;
-	}
+    private String bairro;
 
-	public String getLogradouro() {
-		return logradouro;
-	}
+    private String localidade;
 
-	public void setLogradouro(String logradouro) {
-		this.logradouro = logradouro;
-	}
+    private String uf;
 
-	public String getComplemento() {
-		return complemento;
-	}
+    private String estado;
 
-	public void setComplemento(String complemento) {
-		this.complemento = complemento;
-	}
+    @Override
+    public String toString() {
+        return "Endereco{" +
+                "id=" + id +
+                ", cep='" + cep + '\'' +
+                ", logradouro='" + logradouro + '\'' +
+                ", complemento='" + complemento + '\'' +
+                ", numero='" + numero + '\'' +
+                ", bairro='" + bairro + '\'' +
+                ", localidade='" + localidade + '\'' +
+                ", uf='" + uf + '\'' +
+                ", estado='" + estado + '\'' +
+                '}';
+    }
 
-	public String getBairro() {
-		return bairro;
-	}
+    public Integer getId() {
+        return id;
+    }
 
-	public void setBairro(String bairro) {
-		this.bairro = bairro;
-	}
+    public void setId(Integer id) {
+        this.id = id;
+    }
 
-	public String getLocalidade() {
-		return localidade;
-	}
+    public String getCep() {
+        return cep;
+    }
 
-	public void setLocalidade(String localidade) {
-		this.localidade = localidade;
-	}
+    public void setCep(String cep) {
+        this.cep = cep;
+    }
 
-	public String getUf() {
-		return uf;
-	}
+    public String getLogradouro() {
+        return logradouro;
+    }
 
-	public void setUf(String uf) {
-		this.uf = uf;
-	}
+    public void setLogradouro(String logradouro) {
+        this.logradouro = logradouro;
+    }
 
-	public String getEstado() {
-		return estado;
-	}
+    public String getComplemento() {
+        return complemento;
+    }
 
-	public void setEstado(String estado) {
-		this.estado = estado;
-	}
+    public void setComplemento(String complemento) {
+        this.complemento = complemento;
+    }
 
+    public String getNumero() {
+        return numero;
+    }
+
+    public void setNumero(String numero) {
+        this.numero = numero;
+    }
+
+    public String getBairro() {
+        return bairro;
+    }
+
+    public void setBairro(String bairro) {
+        this.bairro = bairro;
+    }
+
+    public String getLocalidade() {
+        return localidade;
+    }
+
+    public void setLocalidade(String localidade) {
+        this.localidade = localidade;
+    }
+
+    public String getUf() {
+        return uf;
+    }
+
+    public void setUf(String uf) {
+        this.uf = uf;
+    }
+
+    public String getEstado() {
+        return estado;
+    }
+
+    public void setEstado(String estado) {
+        this.estado = estado;
+    }
 }

--- a/julio-parent/common-domain/src/main/java/br/edu/infnet/mono/model/domain/EnderecoLocalidadeQueryResult.java
+++ b/julio-parent/common-domain/src/main/java/br/edu/infnet/mono/model/domain/EnderecoLocalidadeQueryResult.java
@@ -1,0 +1,58 @@
+package br.edu.infnet.mono.model.domain;
+
+public class EnderecoLocalidadeQueryResult {
+    private String cep;
+    private String logradouro;
+    private String complemento;
+    private String bairro;
+    private String localidade;
+    private String uf;
+
+    public String getCep() {
+        return cep;
+    }
+
+    public void setCep(String cep) {
+        this.cep = cep;
+    }
+
+    public String getLogradouro() {
+        return logradouro;
+    }
+
+    public void setLogradouro(String logradouro) {
+        this.logradouro = logradouro;
+    }
+
+    public String getComplemento() {
+        return complemento;
+    }
+
+    public void setComplemento(String complemento) {
+        this.complemento = complemento;
+    }
+
+    public String getBairro() {
+        return bairro;
+    }
+
+    public void setBairro(String bairro) {
+        this.bairro = bairro;
+    }
+
+    public String getLocalidade() {
+        return localidade;
+    }
+
+    public void setLocalidade(String localidade) {
+        this.localidade = localidade;
+    }
+
+    public String getUf() {
+        return uf;
+    }
+
+    public void setUf(String uf) {
+        this.uf = uf;
+    }
+}

--- a/julio-parent/common-domain/src/main/java/br/edu/infnet/mono/model/domain/Funcionario.java
+++ b/julio-parent/common-domain/src/main/java/br/edu/infnet/mono/model/domain/Funcionario.java
@@ -1,221 +1,143 @@
 package br.edu.infnet.mono.model.domain;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
-import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
 
 @Entity
-@Table(name = "funcionarios")
-public class Funcionario {
+public class Funcionario extends Pessoa {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Integer id;
+    private double salario;
 
-	@NotBlank(message = "O nome é obrigatório.")
-	@Size(min = 3, max = 50, message = "O nome deve ter entre 3 e 50 caracteres")
-	@Column(nullable = false, length = 100)
-	private String nome;
+    private boolean ativo;
 
-	@NotBlank(message = "O CPF é obrigatório.")
-	@Pattern(regexp = "^\\d{3}\\.\\d{3}\\.\\d{3}-\\d{2}$", message = "O CPF está inválido. Use o formato: XXX.XXX.XXX-XX")
-	@Column(unique = true, nullable = false, length = 14)
-	private String cpf;
+    @OneToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "endereco_id")
+    private Endereco endereco;
 
-	@NotBlank(message = "O e-mail é obrigatório!")
-	@Email(message = "O e-mail deve estar em formato válido.")
-	private String email;
+    @OneToMany(mappedBy = "funcionario", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+    private List<TicketTarefa> tickettarefas = new ArrayList<>();
 
-	@NotBlank(message = "O telefone é obrigatório.")
-	@Pattern(regexp = "^\\(\\d{2}\\) \\d{4,5}-\\d{4}$", message = "Telefone inválido. Use o formato (XX) XXXXX-XXXX.")
-	@Column(nullable = false, length = 15)
-	private String telefone;
+    @OneToMany(mappedBy = "funcionario", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<Tarefa> tarefas = new ArrayList<>();
 
-	@NotBlank(message = "A matrícula é obrigatória.")
-	@Column(name = "matricula", unique = true, nullable = false)
-	private String matricula;
+    private String cargo;
 
-	@NotNull(message = "O salário é obrigatório!")
-	@Min(value = 0, message = "Salário não pode ser negativo.")
-	@Column(nullable = false)
-	private double salario;
+    private String turno;
 
-	private boolean ativo = true;
+    private String escolaridade;
 
-	// Relacionamento com Endereco
+    private String dataNascimento;
 
-	@OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
-	@Valid
-	@NotNull(message = "O endereço é obrigatório.")
-	private Endereco endereco;
+    private String dataContratacao;
 
-	@Transient
-	@NotBlank(message = "O CEP é obrigatório.")
-	@Pattern(regexp = "^\\d{5}-\\d{3}$", message = "CEP inválido. Use o formato: XXXXX-XXX")
-	private String cepInput;
+    private String dataDemissao;
 
-	@NotBlank(message = "O cargo é obrigatório.")
-	@Size(min = 3, max = 60, message = "Cargo deve ter entre 3 e 60 caracteres.")
-	private String cargo;
+    @Override
+    public String obterTipo() {
+        return "Funcionario";
+    }
 
-	@NotBlank(message = "O turno é obrigatório.")
-	@Size(min = 3, max = 20, message = "Turno deve ter entre 3 e 20 caracteres.")
-	private String turno;
+    @Override
+    public String toString() {
+        String enderecoInfo = (endereco == null) ? "null" : ("Endereco{id=" + endereco.getId() + "}");
+        return String.format(
+                "Funcionario{%s, cargo=%s, turno=%s, escolaridade=%s, dataNascimento=%s, salario=%.2f, ativo=%s, dataContratacao=%s, dataDemissao=%s, endereco=%s}",
+                super.toString(), cargo, turno, escolaridade, dataNascimento, salario, ativo, dataContratacao,
+                dataDemissao, enderecoInfo);
+    }
 
-	@NotBlank(message = "A escolaridade é obrigatória.")
-	@Size(min = 3, max = 50, message = "Escolaridade deve ter entre 3 e 50 caracteres.")
-	private String escolaridade;
+    public double getSalario() {
+        return salario;
+    }
 
-	@NotBlank(message = "A data de nascimento é obrigatória.")
-	@Pattern(regexp = "^\\d{2}/\\d{2}/\\d{4}$", message = "Data de nascimento inválida. Use o formato dd/MM/yyyy.")
-	private String dataNascimento;
+    public void setSalario(double salario) {
+        this.salario = salario;
+    }
 
-	@NotBlank(message = "A data de contratação é obrigatória.")
-	@Pattern(regexp = "^\\d{2}/\\d{2}/\\d{4}$", message = "Data de contratação inválida. Use o formato dd/MM/yyyy.")
-	private String dataContratacao;
+    public boolean isAtivo() {
+        return ativo;
+    }
 
-	@Pattern(regexp = "^$|^\\d{2}/\\d{2}/\\d{4}$", message = "Data de demissão inválida. Use o formato dd/MM/yyyy.")
-	private String dataDemissao;
+    public void setAtivo(boolean ativo) {
+        this.ativo = ativo;
+    }
 
-	public Integer getId() {
-		return id;
-	}
+    public String getCargo() {
+        return cargo;
+    }
 
-	public void setId(Integer id) {
-		this.id = id;
-	}
+    public void setCargo(String cargo) {
+        this.cargo = cargo;
+    }
 
-	public String getNome() {
-		return nome;
-	}
+    public String getTurno() {
+        return turno;
+    }
 
-	public void setNome(String nome) {
-		this.nome = nome;
-	}
+    public void setTurno(String turno) {
+        this.turno = turno;
+    }
 
-	public String getCpf() {
-		return cpf;
-	}
+    public String getEscolaridade() {
+        return escolaridade;
+    }
 
-	public void setCpf(String cpf) {
-		this.cpf = cpf;
-	}
+    public void setEscolaridade(String escolaridade) {
+        this.escolaridade = escolaridade;
+    }
 
-	public String getEmail() {
-		return email;
-	}
+    public String getDataNascimento() {
+        return dataNascimento;
+    }
 
-	public void setEmail(String email) {
-		this.email = email;
-	}
+    public void setDataNascimento(String dataNascimento) {
+        this.dataNascimento = dataNascimento;
+    }
 
-	public String getTelefone() {
-		return telefone;
-	}
+    public String getDataContratacao() {
+        return dataContratacao;
+    }
 
-	public void setTelefone(String telefone) {
-		this.telefone = telefone;
-	}
+    public void setDataContratacao(String dataContratacao) {
+        this.dataContratacao = dataContratacao;
+    }
 
-	public String getMatricula() {
-		return matricula;
-	}
+    public String getDataDemissao() {
+        return dataDemissao;
+    }
 
-	public void setMatricula(String matricula) {
-		this.matricula = matricula;
-	}
+    public void setDataDemissao(String dataDemissao) {
+        this.dataDemissao = dataDemissao;
+    }
 
-	public double getSalario() {
-		return salario;
-	}
+    public Endereco getEndereco() {
+        return endereco;
+    }
 
-	public void setSalario(double salario) {
-		this.salario = salario;
-	}
+    public void setEndereco(Endereco endereco) {
+        this.endereco = endereco;
+    }
 
-	public boolean isAtivo() {
-		return ativo;
-	}
+    public List<TicketTarefa> getTickettarefas() {
+        return tickettarefas;
+    }
 
-	public void setAtivo(boolean ativo) {
-		this.ativo = ativo;
-	}
+    public void setTickettarefas(List<TicketTarefa> tickettarefas) {
+        this.tickettarefas = tickettarefas;
+    }
 
-	public Endereco getEndereco() {
-		return endereco;
-	}
+    public List<Tarefa> getTarefas() {
+        return tarefas;
+    }
 
-	public void setEndereco(Endereco endereco) {
-		this.endereco = endereco;
-	}
-
-	public String getCepInput() {
-		return cepInput;
-	}
-
-	public void setCepInput(String cepInput) {
-		this.cepInput = cepInput;
-	}
-
-	public String getCargo() {
-		return cargo;
-	}
-
-	public void setCargo(String cargo) {
-		this.cargo = cargo;
-	}
-
-	public String getTurno() {
-		return turno;
-	}
-
-	public void setTurno(String turno) {
-		this.turno = turno;
-	}
-
-	public String getEscolaridade() {
-		return escolaridade;
-	}
-
-	public void setEscolaridade(String escolaridade) {
-		this.escolaridade = escolaridade;
-	}
-
-	public String getDataNascimento() {
-		return dataNascimento;
-	}
-
-	public void setDataNascimento(String dataNascimento) {
-		this.dataNascimento = dataNascimento;
-	}
-
-	public String getDataContratacao() {
-		return dataContratacao;
-	}
-
-	public void setDataContratacao(String dataContratacao) {
-		this.dataContratacao = dataContratacao;
-	}
-
-	public String getDataDemissao() {
-		return dataDemissao;
-	}
-
-	public void setDataDemissao(String dataDemissao) {
-		this.dataDemissao = dataDemissao;
-	}
-
+    public void setTarefas(List<Tarefa> tarefas) {
+        this.tarefas = tarefas;
+    }
 }

--- a/julio-parent/common-domain/src/main/java/br/edu/infnet/mono/model/domain/LocalidadePedido.java
+++ b/julio-parent/common-domain/src/main/java/br/edu/infnet/mono/model/domain/LocalidadePedido.java
@@ -1,0 +1,59 @@
+package br.edu.infnet.mono.model.domain;
+
+public class LocalidadePedido {
+
+    private String cep;
+    private String logradouro;
+    private String complemento;
+    private String bairro;
+    private String localidade;
+    private String ufOrigem;
+
+    public String getCep() {
+        return cep;
+    }
+
+    public void setCep(String cep) {
+        this.cep = cep;
+    }
+
+    public String getLogradouro() {
+        return logradouro;
+    }
+
+    public void setLogradouro(String logradouro) {
+        this.logradouro = logradouro;
+    }
+
+    public String getComplemento() {
+        return complemento;
+    }
+
+    public void setComplemento(String complemento) {
+        this.complemento = complemento;
+    }
+
+    public String getBairro() {
+        return bairro;
+    }
+
+    public void setBairro(String bairro) {
+        this.bairro = bairro;
+    }
+
+    public String getLocalidade() {
+        return localidade;
+    }
+
+    public void setLocalidade(String localidade) {
+        this.localidade = localidade;
+    }
+
+    public String getUf() {
+        return ufOrigem;
+    }
+
+    public void setUf(String uf) {
+        this.ufOrigem = uf;
+    }
+}

--- a/julio-parent/common-domain/src/main/java/br/edu/infnet/mono/model/domain/Pessoa.java
+++ b/julio-parent/common-domain/src/main/java/br/edu/infnet/mono/model/domain/Pessoa.java
@@ -1,0 +1,79 @@
+package br.edu.infnet.mono.model.domain;
+
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+
+@MappedSuperclass
+public abstract class Pessoa {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    private String nome;
+
+    private String email;
+
+    private String cpf;
+
+    private String telefone;
+
+    private String dataNascimento;
+
+    @Override
+    public String toString() {
+        return String.format("%s, %s - %s - %s - %s", super.toString(), nome, telefone, cpf, email);
+    }
+
+    public abstract String obterTipo();
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getCpf() {
+        return cpf;
+    }
+
+    public void setCpf(String cpf) {
+        this.cpf = cpf;
+    }
+
+    public String getTelefone() {
+        return telefone;
+    }
+
+    public void setTelefone(String telefone) {
+        this.telefone = telefone;
+    }
+
+    public String getDataNascimento() {
+        return dataNascimento;
+    }
+
+    public void setDataNascimento(String dataNascimento) {
+        this.dataNascimento = dataNascimento;
+    }
+}

--- a/julio-parent/common-domain/src/main/java/br/edu/infnet/mono/model/domain/StatusTicket.java
+++ b/julio-parent/common-domain/src/main/java/br/edu/infnet/mono/model/domain/StatusTicket.java
@@ -1,0 +1,8 @@
+package br.edu.infnet.mono.model.domain;
+
+public enum StatusTicket {
+    ABERTO,
+    EM_ANDAMENTO,
+    FINALIZADO,
+    CANCELADO
+}

--- a/julio-parent/common-domain/src/main/java/br/edu/infnet/mono/model/domain/Tarefa.java
+++ b/julio-parent/common-domain/src/main/java/br/edu/infnet/mono/model/domain/Tarefa.java
@@ -1,0 +1,128 @@
+package br.edu.infnet.mono.model.domain;
+
+import java.math.BigDecimal;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Transient;
+
+@Entity
+public class Tarefa {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    private String descricao;
+
+    @Transient
+    private String codigo;
+
+    @Enumerated(EnumType.STRING)
+    private TipoTarefa tipo;
+
+    private BigDecimal valor;
+
+    private String status;
+
+    @ManyToOne(fetch = FetchType.EAGER, optional = false)
+    @JoinColumn(name = "tickettarefa_id", nullable = false)
+    private TicketTarefa tickettarefa;
+
+    @ManyToOne(fetch = FetchType.EAGER, optional = false)
+    @JoinColumn(name = "funcionario_id", nullable = true)
+    private Funcionario funcionario;
+
+    @ManyToOne(fetch = FetchType.EAGER, optional = false)
+    @JoinColumn(name = "cliente_id", nullable = true)
+    private Cliente cliente;
+
+    @Override
+    public String toString() {
+        return "Tarefa [id=" + id + ", descricao=" + descricao + ", codigo=" + codigo + ", tipo=" + tipo + ", valor=" + valor
+                + ", status=" + status + ", tickettarefa=" + tickettarefa + "]";
+    }
+
+    public String obterTipo() {
+        return "Tarefa";
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getDescricao() {
+        return descricao;
+    }
+
+    public void setDescricao(String descricao) {
+        this.descricao = descricao;
+    }
+
+    public String getCodigo() {
+        return codigo;
+    }
+
+    public void setCodigo(String codigo) {
+        this.codigo = codigo;
+    }
+
+    public TipoTarefa getTipo() {
+        return tipo;
+    }
+
+    public void setTipo(TipoTarefa tipo) {
+        this.tipo = tipo;
+    }
+
+    public BigDecimal getValor() {
+        return valor;
+    }
+
+    public void setValor(BigDecimal valor) {
+        this.valor = valor;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public TicketTarefa getTickettarefa() {
+        return tickettarefa;
+    }
+
+    public void setTickettarefa(TicketTarefa ticket) {
+        this.tickettarefa = ticket;
+    }
+
+    public Funcionario getFuncionario() {
+        return funcionario;
+    }
+
+    public void setFuncionario(Funcionario funcionario) {
+        this.funcionario = funcionario;
+    }
+
+    public Cliente getCliente() {
+        return cliente;
+    }
+
+    public void setCliente(Cliente cliente) {
+        this.cliente = cliente;
+    }
+}

--- a/julio-parent/common-domain/src/main/java/br/edu/infnet/mono/model/domain/TicketTarefa.java
+++ b/julio-parent/common-domain/src/main/java/br/edu/infnet/mono/model/domain/TicketTarefa.java
@@ -1,0 +1,132 @@
+package br.edu.infnet.mono.model.domain;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "TicketTarefa")
+public class TicketTarefa {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(name = "codigo", nullable = false, unique = true, length = 30)
+    private String codigo;
+
+    @Enumerated(EnumType.STRING)
+    private StatusTicket status;
+
+    @Column(name = "valor_total", nullable = false)
+    private BigDecimal valorTotal = BigDecimal.ZERO;
+
+    @ManyToOne(fetch = FetchType.EAGER, optional = false)
+    @JoinColumn(name = "cliente_id", nullable = false)
+    private Cliente cliente;
+
+    @ManyToOne(fetch = FetchType.EAGER, optional = false)
+    @JoinColumn(name = "funcionario_id", nullable = false)
+    private Funcionario funcionario;
+
+    @OneToMany(mappedBy = "tickettarefa", orphanRemoval = true, fetch = FetchType.EAGER)
+    private List<Tarefa> tarefas = new ArrayList<>();
+
+    @Column(name = "data_abertura")
+    private String dataAbertura;
+
+    @Column(name = "data_fechamento")
+    private String dataFechamento;
+
+    @Override
+    public String toString() {
+        return "TicketTarefa [id=" + id + ", codigo=" + codigo + ", status=" + status + ", valorTotal=" + valorTotal
+                + ", cliente=" + cliente + ", funcionario=" + funcionario + ", tarefas=" + tarefas + ", dataAbertura="
+                + dataAbertura + ", dataFechamento=" + dataFechamento + "]";
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getCodigo() {
+        return codigo;
+    }
+
+    public void setCodigo(String codigo) {
+        this.codigo = codigo;
+    }
+
+    public StatusTicket getStatus() {
+        return status;
+    }
+
+    public void setStatus(StatusTicket status) {
+        this.status = status;
+    }
+
+    public BigDecimal getValorTotal() {
+        return valorTotal;
+    }
+
+    public void setValorTotal(BigDecimal valorTotal) {
+        this.valorTotal = valorTotal;
+    }
+
+    public Cliente getCliente() {
+        return cliente;
+    }
+
+    public void setCliente(Cliente cliente) {
+        this.cliente = cliente;
+    }
+
+    public Funcionario getFuncionario() {
+        return funcionario;
+    }
+
+    public void setFuncionario(Funcionario funcionario) {
+        this.funcionario = funcionario;
+    }
+
+    public List<Tarefa> getTarefas() {
+        return tarefas;
+    }
+
+    public void setTarefas(List<Tarefa> tarefas) {
+        this.tarefas = tarefas;
+    }
+
+    public String getDataAbertura() {
+        return dataAbertura;
+    }
+
+    public void setDataAbertura(String dataAbertura) {
+        this.dataAbertura = dataAbertura;
+    }
+
+    public String getDataFechamento() {
+        return dataFechamento;
+    }
+
+    public void setDataFechamento(String dataFechamento) {
+        this.dataFechamento = dataFechamento;
+    }
+}

--- a/julio-parent/common-domain/src/main/java/br/edu/infnet/mono/model/domain/TipoTarefa.java
+++ b/julio-parent/common-domain/src/main/java/br/edu/infnet/mono/model/domain/TipoTarefa.java
@@ -1,0 +1,7 @@
+package br.edu.infnet.mono.model.domain;
+
+public enum TipoTarefa {
+    CORRETIVA,
+    PREVENTIVA,
+    DIAGNOSTICO
+}

--- a/julio-parent/main-app/src/main/java/br/edu/infnet/mono/repository/FuncionarioRepository.java
+++ b/julio-parent/main-app/src/main/java/br/edu/infnet/mono/repository/FuncionarioRepository.java
@@ -10,8 +10,5 @@ import br.edu.infnet.mono.model.domain.Funcionario;
 @Repository
 public interface FuncionarioRepository extends JpaRepository<Funcionario, Integer> {
 
-	Optional<Funcionario> findByCpf(String cpf);
-	Optional<Funcionario> findByMatricula(String matricula);
-	
-
+        Optional<Funcionario> findByCpf(String cpf);
 }

--- a/julio-parent/main-app/src/main/java/br/edu/infnet/mono/repository/TarefaRepository.java
+++ b/julio-parent/main-app/src/main/java/br/edu/infnet/mono/repository/TarefaRepository.java
@@ -1,0 +1,10 @@
+package br.edu.infnet.mono.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import br.edu.infnet.mono.model.domain.Tarefa;
+
+@Repository
+public interface TarefaRepository extends JpaRepository<Tarefa, Integer> {
+}

--- a/julio-parent/main-app/src/main/java/br/edu/infnet/mono/repository/TicketTarefaRepository.java
+++ b/julio-parent/main-app/src/main/java/br/edu/infnet/mono/repository/TicketTarefaRepository.java
@@ -1,0 +1,17 @@
+package br.edu.infnet.mono.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import br.edu.infnet.mono.model.domain.TicketTarefa;
+
+public interface TicketTarefaRepository extends JpaRepository<TicketTarefa, Integer> {
+
+        Optional<TicketTarefa> findByCodigo(String codigo);
+
+        boolean existsByCodigo(String codigo);
+
+        List<TicketTarefa> findByClienteCpf(String cpf);
+}


### PR DESCRIPTION
## Summary
- migrate Julio Jubilado domain entities and enums into the common-domain module with the br.edu.infnet.mono package
- drop validation/external-api dependencies in common-domain to keep only the persistence API
- align main-app repositories with the shared models and add missing JPA repositories

## Testing
- mvn -f julio-parent/pom.xml -pl common-domain,main-app -am clean package *(fails: dependency download blocked with HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d987ea56d48323903dbd88ee4a008d